### PR TITLE
Fix: "null" in namespace causing cluster-ing failure

### DIFF
--- a/vernemq-cluster.yaml
+++ b/vernemq-cluster.yaml
@@ -39,7 +39,7 @@ spec:
         - name: MY_POD_NAME
           valueFrom:
             fieldRef:
-              fieldPath: metadata.name
+              fieldPath: metadata.namespace
         - name: DOCKER_VERNEMQ_DISCOVERY_KUBERNETES
           value: "1"
         - name: DOCKER_VERNEMQ_ERLANG__DISTRIBUTION__PORT_RANGE__MINIMUM


### PR DESCRIPTION
When deploying on Kubernetes you're getting the following error:

```
$ kubectl exec vernemq-0 -- vmq-admin cluster show
Node 'VerneMQ@vernemq-0.null.default.svc.cluster.local' not responding to pings.
command terminated with exit code 1
```

This is because the environment variable for "MY_POD_NAME" has the wrong value in the "fieldPath".
`fieldPath: metadata.name` should be `fieldPath: metadata.namespace`

Thanks!