### PR TITLE
Fix: Missing env vars to prevent "null" nodenaming

### DIFF
--- a/vernemq-cluster.yaml
+++ b/vernemq-cluster.yaml
@@ -42,6 +42,12 @@ spec:
               fieldPath: metadata.name
         - name: DOCKER_VERNEMQ_DISCOVERY_KUBERNETES
           value: "1"
+        - name: DOCKER_VERNEMQ_KUBERNETES_APP_LABEL
+          value: "vernemq"
+        - name: DOCKER_VERNEMQ_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace          
         - name: DOCKER_VERNEMQ_ERLANG__DISTRIBUTION__PORT_RANGE__MINIMUM
           value: "9100"
         - name: DOCKER_VERNEMQ_ERLANG__DISTRIBUTION__PORT_RANGE__MAXIMUM


### PR DESCRIPTION
When deploying to k8 you're getting "null" as part of the service name:

```
$ kubectl exec vernemq-0 -- vmq-admin cluster show
Node 'VerneMQ@vernemq-0.null.default.svc.cluster.local' not responding to pings.
command terminated with exit code 1
```

This is due to a couple missing environment variables that the underlying image uses for node naming.
After applying fix to manifest:

```
$ kubectl exec vernemq-0 -- vmq-admin cluster show
+---------------------------------------------------+-------+
|                       Node                        |Running|
+---------------------------------------------------+-------+
|VerneMQ@vernemq-0.vernemq.default.svc.cluster.local| true  |
|VerneMQ@vernemq-2.vernemq.default.svc.cluster.local| true  |
|VerneMQ@vernemq-1.vernemq.default.svc.cluster.local| true  |
+---------------------------------------------------+-------+
```